### PR TITLE
fix(fold): handle empty providers

### DIFF
--- a/lua/ufo/fold/buffer.lua
+++ b/lua/ufo/fold/buffer.lua
@@ -216,7 +216,7 @@ function FoldBuffer:isFoldMethodsDisabled()
     if not self.providers then
         self:parseProviders()
     end
-    return self.providers[1] == ''
+    return not self.providers or self.providers[1] == ''
 end
 
 ---


### PR DESCRIPTION
Fix for:
```
Error executing vim.schedule lua callback: UnhandledPromiseRejection with the reason:
.../site/pack/packer/start/nvim-ufo/lua/ufo/fold/buffer.lua:219: attempt to index field 'providers' (a nil value)
```

Following the commit: f3662fe9a3b62465ba8e002c243424bd72d8c828