### PR TITLE
[perf] Use frame-key to prevent over-eager drawing of decorations

### DIFF
--- a/lua/ufo/decorator.lua
+++ b/lua/ufo/decorator.lua
@@ -26,12 +26,23 @@ local render = require('ufo.render')
 ---@field disposables UfoDisposable
 local Decorator = {}
 
+local function frameKey()
+    return table.concat({ fn.line("w0") - 1, fn.line("w$"), api.nvim_buf_get_changedtick(0) })
+end
+
 local collection
 local bufnrSet
 local handlerErrorMsg
+local lastFrameKey = frameKey()
 
 ---@diagnostic disable-next-line: unused-local
 local function onStart(name, tick)
+    local thisFrameKey = frameKey()
+    if lastFrameKey == thisFrameKey then
+        return false
+    end
+
+    lastFrameKey = thisFrameKey
     collection = {}
     bufnrSet = {}
 end


### PR DESCRIPTION
I was doing some (unrelated) performance profiling and came across some _very_ over eager decorator callbacks. Maybe this has some side-effects that I don't see, but as far as I can tell everything is working just fine, and graphs look a bit better.

before:
<img width="1646" alt="Screenshot 2023-03-03 at 21 18 45" src="https://user-images.githubusercontent.com/7228095/222821515-3a82b917-6ee2-4b97-9d90-b2325bc4061e.png">


after:
<img width="1662" alt="Screenshot 2023-03-03 at 21 21 08" src="https://user-images.githubusercontent.com/7228095/222821490-c62712ff-ddfe-42ab-ba7a-b3d1378fd647.png">


