### PR TITLE
Fix type annotation

### DIFF
--- a/lua/ufo/model/foldingrange.lua
+++ b/lua/ufo/model/foldingrange.lua
@@ -1,4 +1,4 @@
----@class UfoFoldingRangeKind
+---@alias UfoFoldingRangeKind
 ---| 'comment'
 ---| 'imports'
 ---| 'region'


### PR DESCRIPTION
This type annotation looks to be slightly off. This causes LuaLS to produce errors when I use e.g. the `close_fold_kinds` option:

![image](https://i.imgur.com/V1f9d34.png)
