### PR TITLE
fix: throw UfoFallbackException on RequestFailed

### DIFF
--- a/lua/ufo/provider/lsp/nvim.lua
+++ b/lua/ufo/provider/lsp/nvim.lua
@@ -24,6 +24,7 @@ local errorCodes = {
     UnknownErrorCode = -32001,
     -- Defined by the protocol.
     RequestCancelled = -32800,
+    RequestFailed = -32803,
     ContentModified = -32801,
 }
 
@@ -35,7 +36,7 @@ function NvimClient.request(client, method, params, bufnr)
                 log.error('Client:', client)
                 log.error('All clients:', vim.lsp.get_active_clients({bufnr = bufnr}))
                 local code = err.code
-                if code == errorCodes.RequestCancelled or code == errorCodes.ContentModified then
+                if code == errorCodes.RequestCancelled or code == errorCodes.ContentModified or code == errorCodes.RequestFailed then
                     reject('UfoFallbackException')
                 else
                     reject(err)


### PR DESCRIPTION
[version 3.17](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/) of the LSP specification has a `RequestFailed` error code (= `-32803`).

`haskell-language-server` throws this if a foldRange request fails, leading to an `UnhandledPromiseRejection` to be thrown by nvim-ufo.

Fixes #158 and https://github.com/mrcjkb/haskell-tools.nvim/issues/251.