### PR TITLE
fix(treesitter): fix errors when getting hlId on nvim 0.10.x

### DIFF
--- a/lua/ufo/render/treesitter.lua
+++ b/lua/ufo/render/treesitter.lua
@@ -37,7 +37,13 @@ function M.getHighlightsByRange(bufnr, startRange, endRange, hlGroups)
             if not capture then
                 break
             end
-            local hlId = query.hl_cache[capture]
+            local hlId = assert((function()
+                if query.get_hl_from_capture then -- nvim 0.10+ #26675
+                    return query:get_hl_from_capture(capture)
+                else
+                    return query.hl_cache[capture]
+                end
+            end)())
             local priority = tonumber(metadata.priority) or 100
             local conceal = metadata.conceal
             local sr, sc, er, ec = node:range()


### PR DESCRIPTION
Since neovim [0.10.x 2498747a (2023/12/20)](https://github.com/neovim/neovim/commit/2498747addaf96dacba2000e6fbdf05572d129a3), `hl_cache` (which is private)
is no longer made of a metatable. This results in following errors:

```
E5108: Error executing lua: table index is nil
stack traceback:
        [C]: in function 'rawset'
        .../nvim-ufo/lua/ufo/highlight.lua:31: in function '__index'
        .../nvim-ufo/lua/ufo/render/treesitter.lua:54: in function 'fn'
        $VIMRUNTIME/lua/vim/treesitter/languagetree.lua:489: in function 'for_each_tree'
        $VIMRUNTIME/lua/vim/treesitter/languagetree.lua:493: in function 'for_each_tree'
        .../nvim-ufo/lua/ufo/render/treesitter.lua:19: in function 'getHighlightsByRange'
        .../nvim-ufo/lua/ufo/render/init.lua:132: in function 'mapHighlightLimitByRange'
        .../nvim-ufo/lua/ufo/preview/init.lua:291: in function 'peekFoldedLinesUnderCursor'
```

A temporary fix is to use `query:get_hl_from_capture()`, which is also
an private API, but this prevents the error on nvim nightly.
