### PR TITLE
refactor(treesitter): remove nvim-treesitter dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The goal of nvim-ufo is to make Neovim's fold look modern and keep high performa
 
 - [Neovim](https://github.com/neovim/neovim) 0.7.2 or later
 - [coc.nvim](https://github.com/neoclide/coc.nvim) (optional)
-- [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) (optional)
 
 ### Installation
 
@@ -92,9 +91,9 @@ require('ufo').setup()
 --
 
 -- Option 3: treesitter as a main provider instead
--- Only depend on `nvim-treesitter/queries/filetype/folds.scm`,
+-- (Note: the `nvim-treesitter` plugin is *not* needed.)
+-- ufo uses the same query files for folding (queries/<lang>/folds.scm)
 -- performance and stability are better than `foldmethod=nvim_treesitter#foldexpr()`
-use {'nvim-treesitter/nvim-treesitter', run = ':TSUpdate'}
 require('ufo').setup({
     provider_selector = function(bufnr, filetype, buftype)
         return {'treesitter', 'indent'}


### PR DESCRIPTION
Replace all the use of nvim-treesitter APIs with core vim.treesitter
APIs. No more nvim-treesitter dependency, just core neovim is enough.

This fix makes ufo work without the nvim-treesitter plugin as an
additional dependency. In fact, nvim-treesitter v1.0 deprecates and
removes some APIs that have been migrated to the core neovim APIs
`vim.treesitter`, which makes ufo's previous treesitter provider
implementation incompatible.

Note that this commit does not change the minimum neovim version
requirement, should work fine with neovim 0.7.x.

Implementation note:

There are four APIs that need to be migrated:

- `nvim-treesitter.parsers.get_parser()`: The difference to the core API
  `vim.treesitter.get_parser()` is whether to throw errors when a parser
  is not available (`has_parser`). We simply mimic the previous behavior
  by catching errors.

- `nvim-treesitter.query.get_query()`: The difference to core API
  `vim.treesitter.query.get()` is whether the query file is cached or
  not. This may have a small performance impact; in neovim 0.10.x, this
  function is memoized and thus very fast, but in neovim <= 0.9.x it
  might be slightly slow due to the lack of cache.

  Note: One can consider as well automatically falling back to the old
  nvim-treesitter (v0.9.x) if available, for neovim < 0.10.

- `nvim-treesitter.query.has_folds()` (i.e., `has_query_files()`):
  can be easily replaced with `vim.treesitter.query.get_files`. Also
  there might be a subtle performance difference of whether cache is
  being used (in the old nvim-treesitter implementations) or not.

- `nvim-treesitter.tsrange`: The `TSRange` API has gone. Note that this
  is used only to implement the `#make-range!` directive; it suffices to
  have `node:range()` only for where it's used. Therefore,
  `TSRange.from_nodes()` is the only API we'll need, which can be easily
  backported into the existing `MetaNode` implementation.
