### PR TITLE
feat(provider): marker provider

### DIFF
--- a/lua/ufo/model/foldingrange.lua
+++ b/lua/ufo/model/foldingrange.lua
@@ -2,6 +2,7 @@
 ---| 'comment'
 ---| 'imports'
 ---| 'region'
+---| 'marker'
 
 ---@class UfoFoldingRange
 ---@field startLine number

--- a/lua/ufo/provider/init.lua
+++ b/lua/ufo/provider/init.lua
@@ -9,7 +9,7 @@ local log = require('ufo.lib.log')
 ---@field modules table
 local Provider = {
     modulePathPrefix = 'ufo.provider.',
-    innerProviders = {'lsp', 'treesitter', 'indent'}
+    innerProviders = {'lsp', 'treesitter', 'indent', 'marker'}
 }
 
 local function needFallback(reason)

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -43,24 +43,23 @@ function Marker.getFolds(bufnr)
 
         for lineNum, line in ipairs(lines) do
             -- Open marker
-            local markerColumns = line:find(marker[1], 1, true)
+            local start_column, end_column = line:find(marker[1], 1, true)
 
-            if markerColumns then
+            if start_column then
                 table.insert(openMarkerLines, lineNum)
+            end
 
             -- Close marker
-            else
-                markerColumns = line:find(marker[2], 1, true)
+            start_column = line:find(marker[2], end_column or 1, true)
 
-                if markerColumns then
-                    local relatedOpenMarkerLine = table.remove(openMarkerLines)
+            if start_column then
+                local relatedOpenMarkerLine = table.remove(openMarkerLines)
 
-                    if relatedOpenMarkerLine then
-                        table.insert(
-                        folds,
-                        foldingrange.new(relatedOpenMarkerLine - 1, lineNum - 1, nil, nil, marker[3])
-                        )
-                    end
+                if relatedOpenMarkerLine then
+                    table.insert(
+                    folds,
+                    foldingrange.new(relatedOpenMarkerLine - 1, lineNum - 1, nil, nil, marker[3])
+                    )
                 end
             end
         end

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -8,15 +8,13 @@ local utils = require('ufo.utils')
 local Marker = {}
 
 
--- Defines the 'start' and 'end' markers that the provider will search, and the kind to apply
--- to these markers. Each element of the `markers` list is a list of the 'start', 'end' markers
--- and kind applied, in this order. Example: `local markers = { { 'start marker', 'end marker', 'marker kind' } }`
--- The search is done by marker pair. One marker pair does not affect the other. So the end marker of `markers[0]`
--- will not close the start marker of `markers[1]`, by example.
---
--- This variable will be filled in the first call of the `Marker.getFolds()` function because it depends on the ID
--- of the window consulted in this function. Because of this, it is `nil` for now
-local markers = nil
+-- Data necessary to query folding ranges from VS Code region folding
+local vs_code_marker = {
+    '#region',     -- Start of marker
+    '#endregion',  -- End of marker
+    'region',      -- Kind to be applied to a VS Code region folding
+}
+
 
 --- Function that returns folds for the provided buffer based in the markers
 --- @param bufnr number Vim buffer number
@@ -30,17 +28,15 @@ function Marker.getFolds(bufnr)
         return
     end
 
-    -- Updates the `markers` variable (only once)
-    if markers == nil then
-        markers = {
-            vim.fn.split(vim.wo[winid].foldmarker .. ',marker', ','),  -- Configured Vim marker
-            {
-                '#region',     -- Start of VS code marker
-                '#endregion',  -- End of VS Code marker
-                'region',      -- Kind to be applied to a VS Code region folding
-            }
-        }
-    end
+    -- Defines the 'start' and 'end' markers that the provider will search, and the kind to apply
+    -- to these markers. Each element of the `markers` list is a list of the 'start', 'end' markers
+    -- and kind applied, in this order. Example: `local markers = { { 'start marker', 'end marker', 'marker kind' } }`
+    -- The search is done by marker pair. One marker pair does not affect the other. So the end marker of `markers[0]`
+    -- will not close the start marker of `markers[1]`, by example.
+    local markers = {
+        vim.fn.split(vim.wo[winid].foldmarker .. ',marker', ','),  -- Configured Vim marker
+        vs_code_marker
+    }
 
     -- Query the markers, generate the folding ranges and save in the `folds` variable
     local lines = buf:lines(1, -1)

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -19,8 +19,8 @@ local Marker = {}
 local markers = nil
 
 --- Function that returns folds for the provided buffer based in the markers
--- @param bufnr number Vim buffer number
--- @return UfoFoldingRange[] List of marker folds in the buffer
+--- @param bufnr number Vim buffer number
+--- @return UfoFoldingRange[]|nil Folds List of marker folds in the buffer, or `nil` if they can not be queried
 function Marker.getFolds(bufnr)
     local buf = bufmanager:get(bufnr)
     local winid = utils.getWinByBuf(bufnr)

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -12,64 +12,9 @@ local markers = {
 }
 
 
--- Defines if the provider will only accept markers inside comments
-if vim.g.ufo_markers_only_comment == nil then
-    vim.g.ufo_markers_only_comment = true
-end
-
-
 -- Provider implementation
 
 local Marker = {}
-
-
---- Return the start and end column of the marker
--- If the marker is not found, return nil
--- @param marker string Marker text to be searched
--- @param lines table List of lines of the buffer to search the markers
--- @param lineNum number Line where to search by the marker (starting from 1)
--- @param bufnr number Vim buffer number where to search the marker
--- @return number[]|nil {startColumn, endColumn} or nil if not found
-local function getMarkerPosition(marker, lines, lineNum, bufnr)
-    local startColumn, endColumn = lines[lineNum]:find(marker, 1, true)
-
-    -- 'startColumn' is nil if the marker is not found
-    if startColumn == nil then
-        return nil
-    end
-
-    -- Does not check if the marker is inside a comment
-    if not vim.g.ufo_markers_only_comment then
-        return {startColumn, endColumn}
-    end
-
-    -- Check if the marker is inside a comment. Does it using native vim highlight or Treesitter.
-    -- Treesitter can disable the native highlight search. So it is required to test both. First
-    -- try to use the native highlight, then try to use Treesitter
-
-    local cursorSynID = vim.fn.synIDtrans(vim.fn.synID(lineNum, startColumn, 1))  -- `synIDtrans()` is required to follow highlight links
-
-    if cursorSynID ~= 0 then  -- `cursorSynID` is 0 if has been occurred an error (e.g. Can not find a highlight because of Treesitter)
-        local cursorSynName = vim.fn.synIDattr(cursorSynID, 'name')
-
-        if cursorSynName == 'Comment' then
-            return {startColumn, endColumn}
-        end
-
-    -- Tries to use Treesitter
-    else
-        -- Treesitter line index starts in 0, and lineNum starts in 1. Because of it, the line index must be decreased by 1
-        local captures = vim.treesitter.get_captures_at_pos(bufnr, lineNum-1, startColumn)
-
-        for _, value in ipairs(captures) do
-            if value.capture == 'comment' then
-                return {startColumn, endColumn}
-            end
-        end
-    end
-
-    return nil
-end
 
 
 --- Function that returns folds for the provided buffer based in the markers
@@ -92,14 +37,14 @@ function Marker.getFolds(bufnr)
 
         for lineNum, line in ipairs(lines) do
             -- Open marker
-            local markerColumns = getMarkerPosition(marker[1], lines, lineNum, bufnr)
+            local markerColumns = line:find(marker[1], 1, true)
 
             if markerColumns then
                 table.insert(openMarkerLines, lineNum)
 
             -- Close marker
             else
-                markerColumns = getMarkerPosition(marker[2], lines, lineNum, bufnr)
+                markerColumns = line:find(marker[2], 1, true)
 
                 if markerColumns then
                     local relatedOpenMarkerLine = table.remove(openMarkerLines)

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -15,15 +15,17 @@ function Marker.getFolds(bufnr)
     local buf = bufmanager:get(bufnr)
     local winid = utils.getWinByBuf(bufnr)
 
-    -- Defines the 'start' and 'end' markers that the provider will search. Each element of the `markers` list is a pair of the 'start'
-    -- and 'end' marker. Example: `local markers = { { 'start marker', 'end marker' } }`
-    -- The search is done by marker pair. One marker pair does not affect the other. So the end marker of `markers[0]` will not close the start
-    -- marker of `markers[1]`, by example
+    -- Defines the 'start' and 'end' markers that the provider will search, and the kind to apply
+    -- to these markers. Each element of the `markers` list is a list of the 'start', 'end' markers
+    -- and kind applied, in this order. Example: `local markers = { { 'start marker', 'end marker', 'marker kind' } }`
+    -- The search is done by marker pair. One marker pair does not affect the other. So the end marker of `markers[0]`
+    -- will not close the start marker of `markers[1]`, by example
     local markers = {
-        vim.fn.split(vim.wo[winid].foldmarker, ','),  -- Configured Vim marker
+        vim.fn.split(vim.wo[winid].foldmarker .. ',marker', ','),  -- Configured Vim marker
         {
-            '#region ',   -- Start of VS code marker
-            '#endregion'  -- End of VS Code marker
+            '#region ',    -- Start of VS code marker
+            '#endregion',  -- End of VS Code marker
+            'region',      -- Kind to be applied to a VS Code region folding
         }
     }
 
@@ -56,7 +58,7 @@ function Marker.getFolds(bufnr)
                     if relatedOpenMarkerLine then
                         table.insert(
                         folds,
-                        foldingrange.new(relatedOpenMarkerLine - 1, lineNum - 1, nil, nil, 'marker')
+                        foldingrange.new(relatedOpenMarkerLine - 1, lineNum - 1, nil, nil, marker[3])
                         )
                     end
                 end
@@ -65,7 +67,7 @@ function Marker.getFolds(bufnr)
 
         -- Closes all remaining open markers (they will be open to the end of the file)
         for _, markerStart in ipairs(openMarkerLines) do
-            table.insert(folds, foldingrange.new(markerStart - 1, #lines, nil, nil, 'marker'))
+            table.insert(folds, foldingrange.new(markerStart - 1, #lines, nil, nil, marker[3]))
         end
     end
 

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -2,16 +2,15 @@ local foldingrange = require('ufo.model.foldingrange')
 local bufmanager = require('ufo.bufmanager')
 
 
--- Default configuration variables (can be overwritten by the user)
+-- Defines the 'start' and 'end' markers that the provider will search. Each element of the `markers` list is a pair of the 'start'
+-- and 'end' marker. Example: `local markers = { { 'start marker', 'end marker' } }`
+-- The search is done by marker pair. One marker pair does not affect the other. So the end marker of `markers[0]` will not close the start
+-- marker of `markers[1]`, by example
+local markers = {
+	vim.fn.split(vim.wo.foldmarker, ','),  -- Configured Vim marker
+	{ '#region ', '#endregion' }           -- VS Code marker style
+}
 
--- Defines the start and end marker that the provider will search. It does not use
--- the 'foldmarker' option because it is limited to only one marker pattern
-if vim.g.ufo_markers == nil then
-    vim.g.ufo_markers = {
-        { '{{{', '}}}' },
-        { '#region ', '#endregion' }  -- VS Code marker style
-    }
-end
 
 -- Defines if the provider will only accept markers inside comments
 if vim.g.ufo_markers_only_comment == nil then
@@ -88,7 +87,7 @@ function Marker.getFolds(bufnr)
 
     local folds = {}
 
-    for _, marker in ipairs(vim.g.ufo_markers) do
+    for _, marker in ipairs(markers) do
         local openMarkerLines = {}
 
         for lineNum, line in ipairs(lines) do

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -15,6 +15,11 @@ function Marker.getFolds(bufnr)
     local buf = bufmanager:get(bufnr)
     local winid = utils.getWinByBuf(bufnr)
 
+    -- Does not work with buffers or windows that are not managed by UFO
+    if not buf or winid < 0 then
+        return
+    end
+
     -- Defines the 'start' and 'end' markers that the provider will search, and the kind to apply
     -- to these markers. Each element of the `markers` list is a list of the 'start', 'end' markers
     -- and kind applied, in this order. Example: `local markers = { { 'start marker', 'end marker', 'marker kind' } }`
@@ -28,11 +33,6 @@ function Marker.getFolds(bufnr)
             'region',      -- Kind to be applied to a VS Code region folding
         }
     }
-
-    -- Does not work with buffers that are not managed by UFO
-    if not buf then
-        return
-    end
 
     local lines = buf:lines(1, -1)
 

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -1,18 +1,6 @@
 local foldingrange = require('ufo.model.foldingrange')
 local bufmanager = require('ufo.bufmanager')
-
-
--- Defines the 'start' and 'end' markers that the provider will search. Each element of the `markers` list is a pair of the 'start'
--- and 'end' marker. Example: `local markers = { { 'start marker', 'end marker' } }`
--- The search is done by marker pair. One marker pair does not affect the other. So the end marker of `markers[0]` will not close the start
--- marker of `markers[1]`, by example
-local markers = {
-	vim.fn.split(vim.wo.foldmarker, ','),  -- Configured Vim marker
-	{
-        '#region ',   -- Start of VS code marker
-        '#endregion'  -- End of VS Code marker
-    }
-}
+local utils = require('ufo.utils')
 
 
 -- Provider implementation
@@ -25,6 +13,19 @@ local Marker = {}
 -- @return UfoFoldingRange[] List of marker folds in the buffer
 function Marker.getFolds(bufnr)
     local buf = bufmanager:get(bufnr)
+    local winid = utils.getWinByBuf(bufnr)
+
+    -- Defines the 'start' and 'end' markers that the provider will search. Each element of the `markers` list is a pair of the 'start'
+    -- and 'end' marker. Example: `local markers = { { 'start marker', 'end marker' } }`
+    -- The search is done by marker pair. One marker pair does not affect the other. So the end marker of `markers[0]` will not close the start
+    -- marker of `markers[1]`, by example
+    local markers = {
+        vim.fn.split(vim.wo[winid].foldmarker, ','),  -- Configured Vim marker
+        {
+            '#region ',   -- Start of VS code marker
+            '#endregion'  -- End of VS Code marker
+        }
+    }
 
     -- Does not work with buffers that are not managed by UFO
     if not buf then

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -8,7 +8,10 @@ local bufmanager = require('ufo.bufmanager')
 -- marker of `markers[1]`, by example
 local markers = {
 	vim.fn.split(vim.wo.foldmarker, ','),  -- Configured Vim marker
-	{ '#region ', '#endregion' }           -- VS Code marker style
+	{
+        '#region ',   -- Start of VS code marker
+        '#endregion'  -- End of VS Code marker
+    }
 }
 
 

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -23,7 +23,7 @@ function Marker.getFolds(bufnr)
     local markers = {
         vim.fn.split(vim.wo[winid].foldmarker .. ',marker', ','),  -- Configured Vim marker
         {
-            '#region ',    -- Start of VS code marker
+            '#region',     -- Start of VS code marker
             '#endregion',  -- End of VS Code marker
             'region',      -- Kind to be applied to a VS Code region folding
         }

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -55,7 +55,7 @@ function Marker.getFolds(bufnr)
                     if relatedOpenMarkerLine then
                         table.insert(
                         folds,
-                        foldingrange.new(relatedOpenMarkerLine - 1, lineNum - 1, nil, nil, 'ufo_marker')
+                        foldingrange.new(relatedOpenMarkerLine - 1, lineNum - 1, nil, nil, 'marker')
                         )
                     end
                 end
@@ -64,7 +64,7 @@ function Marker.getFolds(bufnr)
 
         -- Closes all remaining open markers (they will be open to the end of the file)
         for _, markerStart in ipairs(openMarkerLines) do
-            table.insert(folds, foldingrange.new(markerStart - 1, #lines, nil, nil, 'ufo_marker'))
+            table.insert(folds, foldingrange.new(markerStart - 1, #lines, nil, nil, 'marker'))
         end
     end
 

--- a/lua/ufo/provider/marker.lua
+++ b/lua/ufo/provider/marker.lua
@@ -1,0 +1,128 @@
+local foldingrange = require('ufo.model.foldingrange')
+local bufmanager = require('ufo.bufmanager')
+
+
+-- Default configuration variables (can be overwritten by the user)
+
+-- Defines the start and end marker that the provider will search. It does not use
+-- the 'foldmarker' option because it is limited to only one marker pattern
+if vim.g.ufo_markers == nil then
+    vim.g.ufo_markers = {
+        { '{{{', '}}}' },
+        { '#region ', '#endregion' }  -- VS Code marker style
+    }
+end
+
+-- Defines if the provider will only accept markers inside comments
+if vim.g.ufo_markers_only_comment == nil then
+    vim.g.ufo_markers_only_comment = true
+end
+
+
+-- Provider implementation
+
+local Marker = {}
+
+
+--- Return the start and end column of the marker
+-- If the marker is not found, return nil
+-- @param marker string Marker text to be searched
+-- @param lines table List of lines of the buffer to search the markers
+-- @param lineNum number Line where to search by the marker (starting from 1)
+-- @param bufnr number Vim buffer number where to search the marker
+-- @return number[]|nil {startColumn, endColumn} or nil if not found
+local function getMarkerPosition(marker, lines, lineNum, bufnr)
+    local startColumn, endColumn = lines[lineNum]:find(marker, 1, true)
+
+    -- 'startColumn' is nil if the marker is not found
+    if startColumn == nil then
+        return nil
+    end
+
+    -- Does not check if the marker is inside a comment
+    if not vim.g.ufo_markers_only_comment then
+        return {startColumn, endColumn}
+    end
+
+    -- Check if the marker is inside a comment. Does it using native vim highlight or Treesitter.
+    -- Treesitter can disable the native highlight search. So it is required to test both. First
+    -- try to use the native highlight, then try to use Treesitter
+
+    local cursorSynID = vim.fn.synIDtrans(vim.fn.synID(lineNum, startColumn, 1))  -- `synIDtrans()` is required to follow highlight links
+
+    if cursorSynID ~= 0 then  -- `cursorSynID` is 0 if has been occurred an error (e.g. Can not find a highlight because of Treesitter)
+        local cursorSynName = vim.fn.synIDattr(cursorSynID, 'name')
+
+        if cursorSynName == 'Comment' then
+            return {startColumn, endColumn}
+        end
+
+    -- Tries to use Treesitter
+    else
+        -- Treesitter line index starts in 0, and lineNum starts in 1. Because of it, the line index must be decreased by 1
+        local captures = vim.treesitter.get_captures_at_pos(bufnr, lineNum-1, startColumn)
+
+        for _, value in ipairs(captures) do
+            if value.capture == 'comment' then
+                return {startColumn, endColumn}
+            end
+        end
+    end
+
+    return nil
+end
+
+
+--- Function that returns folds for the provided buffer based in the markers
+-- @param bufnr number Vim buffer number
+-- @return UfoFoldingRange[] List of marker folds in the buffer
+function Marker.getFolds(bufnr)
+    local buf = bufmanager:get(bufnr)
+
+    -- Does not work with buffers that are not managed by UFO
+    if not buf then
+        return
+    end
+
+    local lines = buf:lines(1, -1)
+
+    local folds = {}
+
+    for _, marker in ipairs(vim.g.ufo_markers) do
+        local openMarkerLines = {}
+
+        for lineNum, line in ipairs(lines) do
+            -- Open marker
+            local markerColumns = getMarkerPosition(marker[1], lines, lineNum, bufnr)
+
+            if markerColumns then
+                table.insert(openMarkerLines, lineNum)
+
+            -- Close marker
+            else
+                markerColumns = getMarkerPosition(marker[2], lines, lineNum, bufnr)
+
+                if markerColumns then
+                    local relatedOpenMarkerLine = table.remove(openMarkerLines)
+
+                    if relatedOpenMarkerLine then
+                        table.insert(
+                        folds,
+                        foldingrange.new(relatedOpenMarkerLine - 1, lineNum - 1, nil, nil, 'ufo_marker')
+                        )
+                    end
+                end
+            end
+        end
+
+        -- Closes all remaining open markers (they will be open to the end of the file)
+        for _, markerStart in ipairs(openMarkerLines) do
+            table.insert(folds, foldingrange.new(markerStart - 1, #lines, nil, nil, 'ufo_marker'))
+        end
+    end
+
+    return folds
+end
+
+
+return Marker


### PR DESCRIPTION
Add a provider that can fold generic markers. The default ones are:

* '{{{' and '}}}' from vim

* '#region' and '#endregion' from VS Code

You can change the markers with the global variable: `vim.g.ufo_markers`. This provider does not use the 'foldmarker' option because it is limited to only one marker pattern

By default, the provider only tracks markers inside comments to prevent accidental folding. You can enable the folding to markers outside of comments setting the global variable
`vim.g.ufo_markers_only_comment` to false

All folds queried from this provider will have the 'kind' attribute equal to 'ufo_marker'