### PR TITLE
Remove the random number on foldcolumn

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use {'kevinhwang91/nvim-ufo', requires = 'kevinhwang91/promise-async'}
 ```lua
 use {'kevinhwang91/nvim-ufo', requires = 'kevinhwang91/promise-async'}
 
-vim.o.foldcolumn = '1' -- '0' is not bad
+vim.o.foldcolumn = 'auto:9' -- this will auto resize the column width and also remove the random number
 vim.o.foldlevel = 99 -- Using ufo provider need a large value, feel free to decrease the value
 vim.o.foldlevelstart = 99
 vim.o.foldenable = true


### PR DESCRIPTION
My suggestion for minimal configuration to remove the random number on foldcolumn
```diff
- vim.o.foldcolumn = '1'
+ vim.o.foldcolumn = 'auto:9'
```

## before: ` vim.o.foldcolumn = '1'`
![Screenshot from 2024-07-20 at 21:37:20](https://github.com/user-attachments/assets/60a2e189-f6da-454d-a215-a00c223b6fa3)

## after: `vim.o.foldcolumn = 'auto:9'`
![Screenshot from 2024-07-20 at 21:10:31](https://github.com/user-attachments/assets/5d785945-feb9-4b1e-bfb0-825598ffccc2)