### PR TITLE
fix(log): Use `stdpath('log')`

### DIFF
--- a/lua/ufo/lib/log.lua
+++ b/lua/ufo/lib/log.lua
@@ -69,7 +69,7 @@ local function pathSep()
 end
 
 local function init()
-    local logDir = fn.stdpath('cache')
+    local logDir = fn.stdpath('log')
     Log.path = table.concat({logDir, 'ufo.log'}, pathSep())
     local logDateFmt = '%y-%m-%d %T'
 


### PR DESCRIPTION
Neovim has a standard path for log files, so it should be used. It's been available since `v0.7.0-322-g78a1e6bc0`, so compatibility isn't an issue with the current minimum requirement.