### PR TITLE
feat(provider): allow using tree-sitter node types as kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ For example, Changing the text in a buffer will request the providers for folds.
     close_fold_kinds_for_ft = {
         description = [[After the buffer is displayed (opened for the first time), close the
                     folds whose range with `kind` field is included in this option. For now,
-                    'lsp' provider's standardized kinds are 'comment', 'imports' and 'region'.
+                    'lsp' provider's standardized kinds are 'comment', 'imports' and 'region',
+                    and the 'treesitter' provider exposes the underlying node types.
                     This option is a table with filetype as key and fold kinds as value. Use a
                     default value if value of filetype is absent.
                     Run `UfoInspect` for details if your provider has extended the kinds.]],

--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -179,7 +179,8 @@ function Treesitter.getFolds(bufnr)
             stop = stop - 1
         end
         if stop > start then
-            table.insert(ranges, foldingrange.new(start, stop, nil, nil, node:type()))
+            local type = node.type and node:type() or nil
+            table.insert(ranges, foldingrange.new(start, stop, nil, nil, type))
         end
     end
     foldingrange.sortRanges(ranges)

--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -179,7 +179,7 @@ function Treesitter.getFolds(bufnr)
             stop = stop - 1
         end
         if stop > start then
-            table.insert(ranges, foldingrange.new(start, stop))
+            table.insert(ranges, foldingrange.new(start, stop, nil, nil, node:type()))
         end
     end
     foldingrange.sortRanges(ranges)


### PR DESCRIPTION
This PR adds tree-sitter support to close_fold_kinds_for_ft by using node types as kinds.
Works great in practice, using it to auto-fold "done" tasks in a custom document syntax.
Thank you for creating this plugin, it's been central to my workflow for so long :heart: 