### PR TITLE
fix: explicitly declare old behavior for treesitter iter_matches

### DIFF
--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -90,7 +90,7 @@ local function iterFoldMatches(bufnr, parser, root, rootLang)
         return function() end
     end
     ---@diagnostic disable-next-line: need-check-nil
-    local iter = q:iter_matches(p.root, p.source, p.start, p.stop)
+    local iter = q:iter_matches(p.root, p.source, p.start, p.stop, { all = false })
     return function()
         local pattern, match, metadata = iter()
         local matches = {}


### PR DESCRIPTION
## Description

There's a breaking change in neovim's treesitter `iter_matches` https://github.com/neovim/neovim/pull/30193.

For now I think can use the backward compatibility flag `all = false` ( subject to remove in the future ) see:

https://github.com/neovim/neovim/blob/ae9674704ac5586438f60c883e918d448ef0e237/runtime/doc/treesitter.txt#L1243-L1247