### PR TITLE
chore(coc): prevent folds request if coc is disabled for the buffer

### DIFF
--- a/lua/ufo/provider/lsp/coc.lua
+++ b/lua/ufo/provider/lsp/coc.lua
@@ -47,7 +47,7 @@ end
 ---@param kind? string|'comment'|'imports'|'region'
 ---@return Promise
 function CocClient.requestFoldingRange(bufnr, kind)
-    if not CocClient.initialized or not CocClient.enabled then
+    if not CocClient.initialized or not CocClient.enabled or vim.b[bufnr].coc_enabled == 0 then
         return promise.reject('UfoFallbackException')
     end
     return CocClient.runCommand('ufo.foldingRange', bufnr, kind)


### PR DESCRIPTION
Not only reject when coc is not initialized but also when it is disabled for the buffer