### PR TITLE
update available servers function example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ capabilities.textDocument.foldingRange = {
     dynamicRegistration = false,
     lineFoldingOnly = true
 }
-local language_servers = require("lspconfig").util.available_servers() -- or list servers manually like {'gopls', 'clangd'}
+local language_servers = require("lspconfig").util._available_servers() -- or list servers manually like {'gopls', 'clangd'}
 for _, ls in ipairs(language_servers) do
     require('lspconfig')[ls].setup({
         capabilities = capabilities


### PR DESCRIPTION
the available_servers() function in lspconfig was made private in #[e118ce5](https://github.com/neovim/nvim-lspconfig/commit/e118ce58dab72c17216292eef7df4cee3cf60885) 
Therefore updating doc to reflect the changes