### PR TITLE
Fix: Update function call to use new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ capabilities.textDocument.foldingRange = {
     dynamicRegistration = false,
     lineFoldingOnly = true
 }
-local language_servers = require("lspconfig").util.available_servers() -- or list servers manually like {'gopls', 'clangd'}
+local language_servers = require("lspconfig").util._available_servers() -- or list servers manually like {'gopls', 'clangd'}
 for _, ls in ipairs(language_servers) do
     require('lspconfig')[ls].setup({
         capabilities = capabilities


### PR DESCRIPTION
Latest version of lspconfig moved the `available_servers()` to `_available_servers()`