### PR TITLE
remove reference to deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ capabilities.textDocument.foldingRange = {
     dynamicRegistration = false,
     lineFoldingOnly = true
 }
-local language_servers = require("lspconfig").util._available_servers() -- or list servers manually like {'gopls', 'clangd'}
+local language_servers = vim.lsp.get_clients() -- or list servers manually like {'gopls', 'clangd'}
 for _, ls in ipairs(language_servers) do
     require('lspconfig')[ls].setup({
         capabilities = capabilities


### PR DESCRIPTION
getting lsp client info using `vim.lsp.get_clients()` is the recommended method, and lspconfig plugin's util methods may change over time