### PR TITLE
feat(treesitter): capture node range metadata as well

### DIFF
--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -43,14 +43,21 @@ end
 
 --- Return a meta node that represents a range between two nodes, i.e., (#make-range!),
 --- that is similar to the legacy TSRange.from_node() from nvim-treesitter.
-function MetaNode.from_nodes(start_node, end_node)
-    local start_pos = { start_node:start() }
-    local end_pos = { end_node:end_() }
+---@param start_node TSNode Node to be used as the beginning of the range
+---@param end_node TSNode Nodee to be used as the end of the range
+---@param start_metadata vim.treesitter.query.TSMetadata? `start_node` metadata
+---@param end_metadata vim.treesitter.query.TSMetadata? `end_node` metadata
+---@param bufnr integer? Buffer where metadata is from
+---@return TSNode
+function MetaNode.from_nodes(start_node, end_node, start_metadata, end_metadata, bufnr)
+    local start_pos = vim.treesitter.get_range(start_node, bufnr, start_metadata)
+    local end_pos = vim.treesitter.get_range(end_node, bufnr, end_metadata)
+
     return MetaNode:new({
         [1] = start_pos[1],
         [2] = start_pos[2],
-        [3] = end_pos[1],
-        [4] = end_pos[2],
+        [3] = end_pos[4],
+        [4] = end_pos[5],
     })
 end
 
@@ -120,7 +127,8 @@ local function iterFoldMatches(bufnr, parser, root, rootLang)
         if preds then
             for _, pred in pairs(preds) do
                 if pred[1] == 'make-range!' and type(pred[2]) == 'string' and #pred == 4 then
-                    local node = MetaNode.from_nodes(match[pred[3]], match[pred[4]])
+                    local node =
+                        MetaNode.from_nodes(match[pred[3]], match[pred[4]], metadata[pred[3]], metadata[pred[4]], bufnr)
                     table.insert(matches, node)
                 end
             end


### PR DESCRIPTION
Hi there! I hope this isn't too drastic of a change.

Recently venturing into the beautiful yet frustrating world of tree-sitter I have found myself in a corner where I wanted to fold `region` directives in C#, i.e.:

```csharp
        #region Search
        Context.SearchFields = new Dictionary<string, string>()
        {
            { nameof(Response.Name), "Name" },
            { nameof(Response.Email), "Email" },
            { nameof(Response.DateOfBirth), "Date of Birth" },
            { nameof(Response.CountryID), "Country" },
            { nameof(Response.Address), "Address" },
        };

        var people = _peopleService.GetFiltered(searchBy, searchString);
        #endregion
```

I then found out about `make-range` which seems to be supported but not at the same time? Either way, I started using it but found another pitfall: The named capture for these directives encapsulate the next line as well.
Finally I learned about out about the `offset` directive, which adds a `range` metadata to the captured node.

And here is where we're at - this PR which allows for the usage of the `range` metadata for nodes used in the `make-range` directive. I've tested with and without the metadata and it behaved normally, so I don't think it would break anything, please let me know otherwise!

There is one caveat with this though, the other place that calls for `from_nodes` I have left unchanged:

[lua/ufo/provider/treesitter.lua](lua/ufo/provider/treesitter.lua#L112)

It theoretically would benefit from this too and then line `111` would be unnecessary, however offsets cannot be applied to multiple nodes, which is a bit unfortunate.