### PR TITLE
fix(treesitter): put node type value in MetaNode

### DIFF
--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -32,17 +32,18 @@ MetaNode.__index = MetaNode
 
 function MetaNode:new(range, type)
     local o = self == MetaNode and setmetatable({}, self) or self
-    o.value = { range = range, type = type }
+    o._range = range
+    o._type = type
     return o
 end
 
 function MetaNode:range()
-    local range = self.value.range
+    local range = self._range
     return range[1], range[2], range[3], range[4]
 end
 
 function MetaNode:type()
-    return self.value.type
+    return self._type
 end
 
 --- Return a meta node that represents a range between two nodes, i.e., (#make-range!),
@@ -55,7 +56,7 @@ function MetaNode.from_nodes(start_node, end_node)
         [2] = start_pos[2],
         [3] = end_pos[1],
         [4] = end_pos[2],
-    }, nil)
+    })
 end
 
 local function prepareQuery(bufnr, parser, root, rootLang, queryName)

--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -107,7 +107,8 @@ local function iterFoldMatches(bufnr, parser, root, rootLang)
         for id, nodes in pairs(match) do
             local m = metadata[id]
             if m and m.range then
-                node = MetaNode:new(m.range, nodes:type())
+                local type = nodes.type and nodes:type() or nil
+                node = MetaNode:new(m.range, type)
             elseif type(nodes) ~= "table" then
                 -- old behaviou before 0.11
                 node = nodes

--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -30,15 +30,19 @@ end
 local MetaNode = {}
 MetaNode.__index = MetaNode
 
-function MetaNode:new(range)
+function MetaNode:new(range, type)
     local o = self == MetaNode and setmetatable({}, self) or self
-    o.value = range
+    o.value = { range = range, type = type }
     return o
 end
 
 function MetaNode:range()
-    local range = self.value
+    local range = self.value.range
     return range[1], range[2], range[3], range[4]
+end
+
+function MetaNode:type()
+    return self.value.type
 end
 
 --- Return a meta node that represents a range between two nodes, i.e., (#make-range!),
@@ -51,7 +55,7 @@ function MetaNode.from_nodes(start_node, end_node)
         [2] = start_pos[2],
         [3] = end_pos[1],
         [4] = end_pos[2],
-    })
+    }, nil)
 end
 
 local function prepareQuery(bufnr, parser, root, rootLang, queryName)
@@ -102,7 +106,7 @@ local function iterFoldMatches(bufnr, parser, root, rootLang)
         for id, nodes in pairs(match) do
             local m = metadata[id]
             if m and m.range then
-                node = MetaNode:new(m.range)
+                node = MetaNode:new(m.range, nodes:type())
             elseif type(nodes) ~= "table" then
                 -- old behaviou before 0.11
                 node = nodes


### PR DESCRIPTION
Fixes #277. This addition makes custom `close_fold_kinds_for_ft` backed by treesitter node types do its job. See details in the mentioned bug report.