### PR TITLE
feat: close fold current line

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,13 @@ For example, Changing the text in a buffer will request the providers for folds.
                     Run `UfoInspect` for details if your provider has extended the kinds.]],
         default = {default = {}}
     },
-    close_fold_current_line = {
+    close_fold_current_line_for_ft = {
         description = [[Whether to close folds on the current line when the buffer is first
-                    displayed.]],
-        default = false
+                    displayed.
+                    This option is a table with filetype as key and boolean as value. Use a
+                    default value if value of filetype is absent.
+                    ]],
+        default = {default = false}
     },
     fold_virt_text_handler = {
         description = [[A function customize fold virt text, see ### Customize fold text]],
@@ -296,7 +299,10 @@ require('ufo').setup({
         json = {'array'},
         c = {'comment', 'region'}
     },
-    close_fold_current_line = false,
+    close_fold_current_line_for_ft = {
+        default = true,
+        c = false
+    },
     preview = {
         win_config = {
             border = {'', '─', '', '', '', '─', '', ''},

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ For example, Changing the text in a buffer will request the providers for folds.
                     Run `UfoInspect` for details if your provider has extended the kinds.]],
         default = {default = {}}
     },
+    close_fold_current_line = {
+        description = [[Whether to close folds on the current line when the buffer is first
+                    displayed.]],
+        default = false
+    },
     fold_virt_text_handler = {
         description = [[A function customize fold virt text, see ### Customize fold text]],
         default = nil
@@ -291,6 +296,7 @@ require('ufo').setup({
         json = {'array'},
         c = {'comment', 'region'}
     },
+    close_fold_current_line = false,
     preview = {
         win_config = {
             border = {'', '─', '', '', '', '─', '', ''},

--- a/lua/ufo/config.lua
+++ b/lua/ufo/config.lua
@@ -4,7 +4,7 @@ local utils = require('ufo.utils')
 ---@field provider_selector? function
 ---@field open_fold_hl_timeout? number
 ---@field close_fold_kinds_for_ft? table<string, UfoFoldingRangeKind[]>
----@field close_fold_current_line? boolean
+---@field close_fold_current_line_for_ft? table<string, boolean>
 ---@field fold_virt_text_handler? UfoFoldVirtTextHandler A global virtual text handler, reference to `ufo.setFoldVirtTextHandler`
 ---@field enable_get_fold_virt_text? boolean
 ---@field preview? table
@@ -12,7 +12,7 @@ local def = {
     open_fold_hl_timeout = 400,
     provider_selector = nil,
     close_fold_kinds_for_ft = {default = {}},
-    close_fold_current_line = false,
+    close_fold_current_line_for_ft = {default = false},
     fold_virt_text_handler = nil,
     enable_get_fold_virt_text = false,
     preview = {
@@ -66,6 +66,7 @@ local function init()
     utils.validate("open_fold_hl_timeout", Config.open_fold_hl_timeout, 'number')
     utils.validate('provider_selector' , Config.provider_selector, 'function', true)
     utils.validate('close_fold_kinds_for_ft', Config.close_fold_kinds_for_ft, 'table')
+    utils.validate('close_fold_current_line_for_ft', Config.close_fold_current_line_for_ft, 'table')
     utils.validate('fold_virt_text_handler', Config.fold_virt_text_handler, 'function', true)
     utils.validate('preview_mappings', Config.preview.mappings, 'table')
 

--- a/lua/ufo/config.lua
+++ b/lua/ufo/config.lua
@@ -2,6 +2,7 @@
 ---@field provider_selector? function
 ---@field open_fold_hl_timeout number
 ---@field close_fold_kinds_for_ft table<string, UfoFoldingRangeKind[]>
+---@field close_fold_current_line boolean
 ---@field fold_virt_text_handler? UfoFoldVirtTextHandler A global virtual text handler, reference to `ufo.setFoldVirtTextHandler`
 ---@field enable_get_fold_virt_text boolean
 ---@field preview table
@@ -9,6 +10,7 @@ local def = {
     open_fold_hl_timeout = 400,
     provider_selector = nil,
     close_fold_kinds_for_ft = {default = {}},
+    close_fold_current_line = false,
     fold_virt_text_handler = nil,
     enable_get_fold_virt_text = false,
     preview = {

--- a/lua/ufo/config.lua
+++ b/lua/ufo/config.lua
@@ -4,7 +4,7 @@ local utils = require('ufo.utils')
 ---@field provider_selector? function
 ---@field open_fold_hl_timeout? number
 ---@field close_fold_kinds_for_ft? table<string, UfoFoldingRangeKind[]>
----@field close_fold_current_line boolean
+---@field close_fold_current_line? boolean
 ---@field fold_virt_text_handler? UfoFoldVirtTextHandler A global virtual text handler, reference to `ufo.setFoldVirtTextHandler`
 ---@field enable_get_fold_virt_text? boolean
 ---@field preview? table

--- a/lua/ufo/fold/init.lua
+++ b/lua/ufo/fold/init.lua
@@ -227,7 +227,7 @@ function Fold:initialize(ns)
     event:on('BufAttach', Fold.attach, self.disposables)
     event:on('DiffModeChanged', handleDiffMode, self.disposables)
     table.insert(self.disposables, manager:initialize(ns, config.provider_selector,
-        config.close_fold_kinds_for_ft, config.close_fold_current_line))
+        config.close_fold_kinds_for_ft, config.close_fold_current_line_for_ft))
     return self
 end
 

--- a/lua/ufo/fold/init.lua
+++ b/lua/ufo/fold/init.lua
@@ -227,7 +227,7 @@ function Fold:initialize(ns)
     event:on('BufAttach', Fold.attach, self.disposables)
     event:on('DiffModeChanged', handleDiffMode, self.disposables)
     table.insert(self.disposables, manager:initialize(ns, config.provider_selector,
-        config.close_fold_kinds_for_ft))
+        config.close_fold_kinds_for_ft, config.close_fold_current_line))
     return self
 end
 

--- a/lua/ufo/fold/manager.lua
+++ b/lua/ufo/fold/manager.lua
@@ -21,14 +21,14 @@ local FoldBufferManager = {}
 ---@param selector function
 ---@param closeKindsMap table<string,UfoFoldingRangeKind[]>
 ---@return UfoFoldBufferManager
-function FoldBufferManager:initialize(namespace, selector, closeKindsMap, closeCurrentLineFolds)
+function FoldBufferManager:initialize(namespace, selector, closeKindsMap, closeCurrentLineFoldsMap)
     if self.initialized then
         return self
     end
     self.ns = namespace
     self.providerSelector = selector
     self.closeKindsMap = closeKindsMap
-    self.closeCurrentLineFolds = closeCurrentLineFolds
+    self.closeCurrentLineFoldsMap = closeCurrentLineFoldsMap
     self.buffers = {}
     self.initialized = true
     self.disposables = {}
@@ -176,11 +176,12 @@ function FoldBufferManager:applyFoldRanges(bufnr, ranges, manual)
     if not manual and not fb.scanned or windows then
         rowPairs = self:getRowPairs(winid)
         local kinds = self.closeKindsMap[fb:filetype()] or self.closeKindsMap.default
+        local closeCurrentLineFolds = self.closeCurrentLineFoldsMap[fb:filetype()] or self.closeCurrentLineFoldsMap.default
         local curRow = api.nvim_win_get_cursor(winid)[1] - 1
         for _, range in ipairs(fb.foldRanges) do
             if range.kind and vim.tbl_contains(kinds, range.kind) then
                 local startLine, endLine = range.startLine, range.endLine
-                if self.closeCurrentLineFolds or curRow <= startLine or curRow > endLine then
+                if closeCurrentLineFolds or curRow <= startLine or curRow > endLine then
                     rowPairs[startLine] = endLine
                 end
             end

--- a/lua/ufo/fold/manager.lua
+++ b/lua/ufo/fold/manager.lua
@@ -21,13 +21,14 @@ local FoldBufferManager = {}
 ---@param selector function
 ---@param closeKindsMap table<string,UfoFoldingRangeKind[]>
 ---@return UfoFoldBufferManager
-function FoldBufferManager:initialize(namespace, selector, closeKindsMap)
+function FoldBufferManager:initialize(namespace, selector, closeKindsMap, closeCurrentLineFolds)
     if self.initialized then
         return self
     end
     self.ns = namespace
     self.providerSelector = selector
     self.closeKindsMap = closeKindsMap
+    self.closeCurrentLineFolds = closeCurrentLineFolds
     self.buffers = {}
     self.initialized = true
     self.disposables = {}
@@ -177,7 +178,7 @@ function FoldBufferManager:applyFoldRanges(bufnr, ranges, manual)
         for _, range in ipairs(fb.foldRanges) do
             if range.kind and vim.tbl_contains(kinds, range.kind) then
                 local startLine, endLine = range.startLine, range.endLine
-                if curRow < startLine or curRow > endLine then
+                if self.closeCurrentLineFolds or curRow < startLine or curRow > endLine then
                     rowPairs[startLine] = endLine
                 end
             end


### PR DESCRIPTION
This PR enhances the plugin options so that you can configure it to close all folds matching the `close_fold_kinds_for_ft` kinds, even if the cursor is inside of one.

I often open C# files with a lot of using statements and want them to be closed by default, but the plugin checks if the cursor is between the fold range when determining whether to fold it or not.