### PR TITLE
fix(treesitter): compatibility with Neovim 0.11

### DIFF
--- a/lua/ufo/provider/treesitter.lua
+++ b/lua/ufo/provider/treesitter.lua
@@ -1,5 +1,6 @@
 local bufmanager = require('ufo.bufmanager')
 local foldingrange = require('ufo.model.foldingrange')
+local utils = require('ufo.utils')
 
 ---@class UfoTreesitterProvider
 ---@field hasProviders table<string, boolean>
@@ -107,7 +108,12 @@ local function iterFoldMatches(bufnr, parser, root, rootLang)
         for id, nodes in pairs(match) do
             local m = metadata[id]
             if m and m.range then
-                local type = nodes.type and nodes:type() or nil
+                local type
+                if utils.has11() then
+                    type = nodes[1].type and nodes[1]:type() or nil
+                else
+                    type = nodes.type and nodes:type() or nil
+                end
                 node = MetaNode:new(m.range, type)
             elseif type(nodes) ~= "table" then
                 -- old behaviou before 0.11
@@ -179,6 +185,9 @@ function Treesitter.getFolds(bufnr)
     if not parser then
         self.hasProviders[ft] = false
         error('UfoFallbackException')
+    end
+    if utils.has11() then
+        parser:parse()
     end
 
     local ranges = {}

--- a/lua/ufo/utils.lua
+++ b/lua/ufo/utils.lua
@@ -7,6 +7,18 @@ local uv = vim.loop
 
 ---
 ---@return fun(): boolean
+M.has11 = (function()
+    local has11
+    return function()
+        if has11 == nil then
+            has11 = fn.has('nvim-0.11') == 1
+        end
+        return has11
+    end
+end)()
+
+---
+---@return fun(): boolean
 M.has10 = (function()
     local has10
     return function()


### PR DESCRIPTION
Update the treesitter provider accordingly to changes in Neovim 0.11:

- [Query:iter_matches()](https://neovim.io/doc/user/treesitter.html#Query%3Aiter_matches()) correctly returns all matching nodes in a match instead of only the last node. This means that the returned table maps capture IDs to a list of nodes that need to be iterated over. For backwards compatibility, an option `all=false` (only return the last matching node) is provided that will be removed in a future release.

- [vim.treesitter.get_parser()](https://neovim.io/doc/user/treesitter.html#vim.treesitter.get_parser()) and [vim.treesitter.start()](https://neovim.io/doc/user/treesitter.html#vim.treesitter.start()) no longer parse the tree before returning. Scripts must call [LanguageTree:parse()](https://neovim.io/doc/user/treesitter.html#LanguageTree%3Aparse()) explicitly.

    ```lua
    local p = vim.treesitter.get_parser(0, 'c')
    p:parse()
    ```