### PR TITLE
feat(docs): mark UfoConfig fields as optional

### DIFF
--- a/lua/ufo/config.lua
+++ b/lua/ufo/config.lua
@@ -1,10 +1,10 @@
 ---@class UfoConfig
 ---@field provider_selector? function
----@field open_fold_hl_timeout number
----@field close_fold_kinds_for_ft table<string, UfoFoldingRangeKind[]>
+---@field open_fold_hl_timeout? number
+---@field close_fold_kinds_for_ft? table<string, UfoFoldingRangeKind[]>
 ---@field fold_virt_text_handler? UfoFoldVirtTextHandler A global virtual text handler, reference to `ufo.setFoldVirtTextHandler`
----@field enable_get_fold_virt_text boolean
----@field preview table
+---@field enable_get_fold_virt_text? boolean
+---@field preview? table
 local def = {
     open_fold_hl_timeout = 400,
     provider_selector = nil,


### PR DESCRIPTION
Mark fields `open_fold_hl_timeout`, `close_fold_kinds_for_ft`,
`enable_get_fold_virt_text`, and `preview` in the `UfoConfig` as
optional.

This allows the user to annotate his config options as:
```lua
---@type UfoConfig
opts = {
    -- ...
}
```
and rely on the defined default values in the plugin. This is beneficial
for the user because it allows completion of the fields of the config
without giving diagnostic warnings.
