### PR TITLE
feat(utils): add utils.validate to replace the deprecated usage of vim.validate

### DIFF
--- a/lua/ufo.lua
+++ b/lua/ufo.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local utils = require("ufo.utils")
 
 ---Export methods to the users, `require('ufo').method(...)`
 ---@class Ufo
@@ -135,7 +136,8 @@ end
 ---@param ranges UfoFoldingRange[]
 ---@return number winid return the winid if successful, otherwise return -1
 function M.applyFolds(bufnr, ranges)
-    vim.validate({bufnr = {bufnr, 'number', true}, ranges = {ranges, 'table'}})
+    utils.validate('bufnr', bufnr, 'number', true)
+    utils.validate('ranges', ranges, 'table')
     return require('ufo.fold').apply(bufnr, ranges, true)
 end
 
@@ -186,7 +188,8 @@ end
 ---@param bufnr number
 ---@param handler UfoFoldVirtTextHandler
 function M.setFoldVirtTextHandler(bufnr, handler)
-    vim.validate({bufnr = {bufnr, 'number', true}, handler = {handler, 'function'}})
+    utils.validate('bufnr', bufnr, 'number', true)
+    utils.validate('handler',handler, 'function')
     require('ufo.decorator'):setVirtTextHandler(bufnr, handler)
 end
 

--- a/lua/ufo/config.lua
+++ b/lua/ufo/config.lua
@@ -1,3 +1,5 @@
+local utils = require('ufo.utils')
+
 ---@class UfoConfig
 ---@field provider_selector? function
 ---@field open_fold_hl_timeout? number
@@ -59,13 +61,11 @@ local function init()
     local ufo = require('ufo')
     ---@type UfoConfig
     Config = vim.tbl_deep_extend('keep', ufo._config or {}, def)
-    vim.validate({
-        open_fold_hl_timeout = {Config.open_fold_hl_timeout, 'number'},
-        provider_selector = {Config.provider_selector, 'function', true},
-        close_fold_kinds_for_ft = {Config.close_fold_kinds_for_ft, 'table'},
-        fold_virt_text_handler = {Config.fold_virt_text_handler, 'function', true},
-        preview_mappings = {Config.preview.mappings, 'table'}
-    })
+    utils.validate("open_fold_hl_timeout", Config.open_fold_hl_timeout, 'number')
+    utils.validate('provider_selector' ,Config.provider_selector, 'function', true)
+    utils.validate('close_fold_kinds_for_ft', Config.close_fold_kinds_for_ft, 'table')
+    utils.validate('fold_virt_text_handler',Config.fold_virt_text_handler, 'function', true)
+    utils.validate('preview_mappings',Config.preview.mappings, 'table')
 
     local preview = Config.preview
     for msg, key in pairs(preview.mappings) do

--- a/lua/ufo/lib/debounce.lua
+++ b/lua/ufo/lib/debounce.lua
@@ -1,4 +1,5 @@
 local uv = vim.loop
+local utils = require('ufo.utils')
 
 ---@class UfoDebounce
 ---@field timer userdata
@@ -15,11 +16,10 @@ local Debounce = {}
 ---@param leading? boolean
 ---@return UfoDebounce
 function Debounce:new(fn, wait, leading)
-    vim.validate({
-        fn = {fn, 'function'},
-        wait = {wait, 'number'},
-        leading = {leading, 'boolean', true}
-    })
+    utils.validate('fn', fn, 'function')
+    utils.validate('wait', wait, 'number')
+    utils.validate('leading' , leading, 'boolean', true)
+
     local o = setmetatable({}, self)
     o.timer = nil
     o.fn = vim.schedule_wrap(fn)

--- a/lua/ufo/render/init.lua
+++ b/lua/ufo/render/init.lua
@@ -261,15 +261,13 @@ end
 ---@param shared? boolean
 ---@return Promise
 function M.highlightLinesWithTimeout(handle, hlGroup, ns, start, finish, delay, shared)
-    vim.validate({
-        handle = {handle, 'number'},
-        hlGroup = {hlGroup, 'string'},
-        ns = {ns, 'number'},
-        start = {start, 'number'},
-        finish = {finish, 'number'},
-        delay = {delay, 'number', true},
-        shared = {shared, 'boolean', true},
-    })
+    utils.validate('handle',  handle, 'number')
+    utils.validate('hlGroup',  hlGroup, 'string')
+    utils.validate('ns',  ns, 'number')
+    utils.validate('start',  start, 'number')
+    utils.validate('finish',  finish, 'number')
+    utils.validate('delay',  delay, 'number', true)
+    utils.validate('shared',  shared, 'boolean', true)
     local ids = {}
     local onFulfilled
     if shared then

--- a/lua/ufo/utils.lua
+++ b/lua/ufo/utils.lua
@@ -353,4 +353,19 @@ function M.wrow(winid)
     return M.winCall(winid, fn.winline) - 1
 end
 
+---
+--- @param name string Argument name
+--- @param value any Argument value
+--- @param validator vim.validate.Validator
+--- @param optional? boolean Argument is optional (may be omitted)
+function M.validate(name, value, validator, optional)
+    if M.has11() then
+        vim.validate(name, value, validator, optional)
+    else
+        local spec = {}
+        spec[name] = {value, validator, optional}
+        vim.validate(spec)
+    end
+end
+
 return M


### PR DESCRIPTION
As the nvim 0.11 released, the `vim.validate` has deprecated the usage of `vim.validate(spec)`.

I think it's ok to use a new api `utils.validate` which is compatible with the old version of nvim instance.
