### PR TITLE
fix(manager): UnhandledPromiseRejection: invalid in command-line window

### DIFF
--- a/lua/ufo/fold/manager.lua
+++ b/lua/ufo/fold/manager.lua
@@ -165,6 +165,8 @@ function FoldBufferManager:applyFoldRanges(bufnr, ranges, manual)
         return -1
     elseif not vim.wo[winid].foldenable or utils.isDiffOrMarkerFold(winid) then
         return -1
+    elseif vim.fn.getcmdwintype() ~= "" then
+        return -1
     elseif utils.mode() ~= 'n' then
         return -1
     end


### PR DESCRIPTION
Fixes issue that happens when you quickly open cmd window (pressing `:` and then `ctrl+f`) when nvim-ufo is starting.

```sh
Error executing vim.schedule lua callback: UnhandledPromiseRejection with the reason:
...e/nvim/site/pack/plugins/opt/ufo/lua/ufo/fold/driver.lua:47: Error executing lua: vim/_editor.lua:0: nvim_exec2(), line 1: Vim(mkview):E11: Invalid in command-line window
```