### PR TITLE
fix(fold): fold text after vim highlighter parsing state change

### DIFF
--- a/lua/ufo/decorator.lua
+++ b/lua/ufo/decorator.lua
@@ -44,7 +44,7 @@ end
 local function onWin(name, winid, bufnr, topRow, botRow)
     local fb = fold.get(bufnr)
     if not fb or fb.foldedLineCount == 0 and not vim.wo[winid].foldenable or
-        render.rendering(bufnr) then
+        render.rendering(bufnr, winid) then
         -- vim.treesitter.highlighter._on_win will fire next redraw if parser done
         collection[winid] = nil
         return false

--- a/lua/ufo/render/init.lua
+++ b/lua/ufo/render/init.lua
@@ -118,12 +118,12 @@ local function mapInlayMarkers(bufnr, startRow, marks, ns)
 end
 
 if utils.has11() then
-    function M.rendering(bufnr)
-        return not treesitter.parserFinished(bufnr)
+    function M.rendering(bufnr, winid)
+        return not treesitter.parserFinished(bufnr, winid)
     end
 else
     ---@diagnostic disable-next-line: unused-local
-    function M.rendering(bufnr) return false end
+    function M.rendering(bufnr, winid) return false end
 end
 
 function M.mapHighlightLimitByRange(srcBufnr, dstBufnr, baseRow, startRange, endRange, text, ns)

--- a/lua/ufo/render/treesitter.lua
+++ b/lua/ufo/render/treesitter.lua
@@ -2,11 +2,22 @@ local highlighter = require('vim.treesitter.highlighter')
 
 local M = {}
 
-function M.parserFinished(bufnr)
+function M.parserFinished(bufnr, winid)
     local data = highlighter.active[bufnr]
     if not data then
         return true
     end
+
+    -- After https://github.com/neovim/neovim/commit/faae1e72a27b31017be639f24e3a9b374b4be255
+    if type(data.parsing) == "table" then
+        if data.parsing[winid] then
+            return false
+        else
+            return true
+        end
+    end
+
+    -- Before https://github.com/neovim/neovim/commit/faae1e72a27b31017be639f24e3a9b374b4be255
     if data.parsing then
         return false
     else


### PR DESCRIPTION
Problem: The fold text was broken (shows 0 instead of the buffer text) after `vim.treesitter.highlighter` changed its `parsing` property to be a `table` instead of a `boolean` (changed in https://github.com/neovim/neovim/commit/faae1e72a27b31017be639f24e3a9b374b4be255).

Solution: Adapt the code to detect when `parsing` is a table, and get the necessary information from that table.

For backward compatibility, keep the old behavior if `parsing` it is not a `table`.

## Before

<img width="559" alt="image" src="https://github.com/user-attachments/assets/b06faae4-9d88-4c1b-a1bc-130dff7c50cc" />


## After

<img width="617" alt="image" src="https://github.com/user-attachments/assets/15b14a0d-563b-4a1c-9735-62b8e717d535" />
