### PR TITLE
fix(decorator): fix nested redraw issue

### DIFF
--- a/lua/ufo/decorator.lua
+++ b/lua/ufo/decorator.lua
@@ -133,13 +133,13 @@ local function onEnd(name, tick)
     self.lastWinid = self.curWinid
     if needRedraw then
         log.debug('Need redraw.')
-            vim.schedule(function()
-                if utils.has10() then
-                    api.nvim__redraw({valid = true, flush = true})
-                else
-                    cmd('redraw')
-                end
-            end)
+        vim.schedule(function()
+            if utils.has10() then
+                api.nvim__redraw({valid = true, flush = true})
+            else
+                cmd('redraw')
+            end
+        end)
     end
     debounced()
 end


### PR DESCRIPTION
when redraw whole windows inside a redraw cycle triggers ext_ui use nvim_buf_set_text which is didn't allowed in a decoration provider callback,fix it by defer redraw later using vim.schedule.

the error msg is:
Error in "msg_ruler" UI event handler (ns=nvim._ext_ui):
Lua: /usr/share/nvim/runtime/lua/vim/_extui/messages.lua:162: E565: Not allowed to change text or change window 

As mostly plugin projects all using vim.schedule to defer a window level redraw, even without this newly added error we shall move to this anyway.