### PR TITLE
feat(foldtext): add option to skip foldtext override

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ For example, Changing the text in a buffer will request the providers for folds.
                     ctx table as 6th parameter in `fold_virt_text_handler`]],
         default = false
     },
+    override_foldtext = {
+        description = [[Override foldtext with (custom) virt text handler]],
+        default = true
+    },
     preview = {
         description = [[Configure the options for preview window and remap the keys for current
                     buffer and preview buffer if the preview window is displayed.

--- a/lua/ufo/config.lua
+++ b/lua/ufo/config.lua
@@ -7,6 +7,7 @@ local utils = require('ufo.utils')
 ---@field close_fold_current_line_for_ft? table<string, boolean>
 ---@field fold_virt_text_handler? UfoFoldVirtTextHandler A global virtual text handler, reference to `ufo.setFoldVirtTextHandler`
 ---@field enable_get_fold_virt_text? boolean
+---@field override_foldtext? boolean
 ---@field preview? table
 local def = {
     open_fold_hl_timeout = 400,
@@ -15,6 +16,7 @@ local def = {
     close_fold_current_line_for_ft = {default = false},
     fold_virt_text_handler = nil,
     enable_get_fold_virt_text = false,
+    override_foldtext = true,
     preview = {
         win_config = {
             border = 'rounded',

--- a/lua/ufo/fold/init.lua
+++ b/lua/ufo/fold/init.lua
@@ -36,6 +36,9 @@ local function tryUpdateFold(bufnr)
 end
 
 local function setFoldText(bufnr)
+    if not config.override_foldtext then
+        return
+    end
     local winid = utils.getWinByBuf(bufnr)
     if not utils.isWinValid(winid) then
         return


### PR DESCRIPTION
Hey there,

thanks for the great plugin!

Since the merge of [neovim#2750](https://github.com/neovim/neovim/pull/20750), an option to set the `foldtext` to an empty string `vim.o.foldtext = ""` basically renders folds as if unfolded (except for the `Folded` highlightgroup and the fillchar `fold`).

I added an option to disable the override of foldtext done by nvim-ufo to take advantage of this.

This solves #301 and a few other problems for me.